### PR TITLE
feat: add source ip address to logs

### DIFF
--- a/pkg/firewall/http_proxy.go
+++ b/pkg/firewall/http_proxy.go
@@ -179,6 +179,7 @@ func (p *HttpProxy) allow(w http.ResponseWriter, r *http.Request, cache *RuleCac
 		"path":     r.URL.Path,
 		"method":   r.Method,
 		"duration": duration,
+		"source":   GetSourceIP(r),
 	}).Info("request allowed")
 }
 
@@ -208,6 +209,7 @@ func (p *HttpProxy) cacheHit(w http.ResponseWriter, r *http.Request, requestHash
 		"method":   r.Method,
 		"cache":    cacheHit,
 		"duration": duration,
+		"source":   GetSourceIP(r),
 	}).Info("request allowed")
 }
 
@@ -228,6 +230,7 @@ func (p *HttpProxy) cacheMiss(w http.ResponseWriter, r *http.Request, requestHas
 		"method":   r.Method,
 		"cache":    cacheMiss,
 		"duration": duration,
+		"source":   GetSourceIP(r),
 	}).Info("request allowed")
 
 	b, err := ww.GetWrittenBytes()
@@ -256,5 +259,6 @@ func (p *HttpProxy) deny(w http.ResponseWriter, r *http.Request, startTime time.
 		"path":     r.URL.Path,
 		"method":   r.Method,
 		"duration": duration,
+		"source":   GetSourceIP(r),
 	}).Info("request denied")
 }

--- a/pkg/firewall/http_utils.go
+++ b/pkg/firewall/http_utils.go
@@ -77,3 +77,14 @@ func (w *ResponseWriterWrapper) GetStatusCode() int {
 func (w *ResponseWriterWrapper) GetWrittenBytes() ([]byte, error) {
 	return io.ReadAll(w.buf)
 }
+
+func GetSourceIP(r *http.Request) string {
+	IPAddress := r.Header.Get("X-Real-Ip")
+	if IPAddress == "" {
+		IPAddress = r.Header.Get("X-Forwarded-For")
+	}
+	if IPAddress == "" {
+		IPAddress = r.RemoteAddr
+	}
+	return IPAddress
+}

--- a/pkg/firewall/jsonrpc_handler.go
+++ b/pkg/firewall/jsonrpc_handler.go
@@ -170,6 +170,7 @@ func (h *JsonRpcHandler) handleHttpSingle(request *JsonRpcMsg, w http.ResponseWr
 							"path":     request.Params,
 							"cache":    cacheHit,
 							"duration": duration,
+							"source":   GetSourceIP(r),
 						}).Info("request allowed")
 						return
 					}
@@ -187,6 +188,7 @@ func (h *JsonRpcHandler) handleHttpSingle(request *JsonRpcMsg, w http.ResponseWr
 						"params":   request.Params,
 						"cache":    cacheMiss,
 						"duration": duration,
+						"source":   GetSourceIP(r),
 					}).Info("request allowed")
 					return
 				}
@@ -203,6 +205,7 @@ func (h *JsonRpcHandler) handleHttpSingle(request *JsonRpcMsg, w http.ResponseWr
 					"method":   request.Method,
 					"params":   request.Params,
 					"duration": duration,
+					"source":   GetSourceIP(r),
 				}).Info("request allowed")
 				return
 
@@ -220,6 +223,7 @@ func (h *JsonRpcHandler) handleHttpSingle(request *JsonRpcMsg, w http.ResponseWr
 					"method":   request.Method,
 					"params":   request.Params,
 					"duration": duration,
+					"source":   GetSourceIP(r),
 				}).Info("request denied")
 				return
 
@@ -242,6 +246,7 @@ func (h *JsonRpcHandler) handleHttpSingle(request *JsonRpcMsg, w http.ResponseWr
 			"method":   request.Method,
 			"params":   request.Params,
 			"duration": duration,
+			"source":   GetSourceIP(r),
 		}).Info("request allowed")
 	} else {
 		h.writeSingleResponse(w, UnauthorizedResponse(request))
@@ -257,6 +262,7 @@ func (h *JsonRpcHandler) handleHttpSingle(request *JsonRpcMsg, w http.ResponseWr
 			"method":   request.Method,
 			"params":   request.Params,
 			"duration": duration,
+			"source":   GetSourceIP(r),
 		}).Info("request denied")
 	}
 }
@@ -375,6 +381,7 @@ func (h *JsonRpcHandler) handleHttpBatch(requests JsonRpcMsgs, w http.ResponseWr
 		"cache_hits":   cacheHits,
 		"cache_misses": cacheMisses,
 		"duration":     duration,
+		"source":       GetSourceIP(r),
 	}).Info("processed batch of requests")
 }
 


### PR DESCRIPTION
Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "source" field to log messages for allowed and denied requests.
  - Introduced a `GetSourceIP` function to retrieve the source IP address from an HTTP request.
  - Modified the `JsonRpcWebSocketProxy` to include an additional `source` parameter for logging the request source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->